### PR TITLE
[compilation] make eslint-plugin version not so strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "extends": "@diia-inhouse/configs/dist/semantic-release/package"
     },
     "dependencies": {
-        "@diia-inhouse/eslint-plugin": "1.6.0",
+        "@diia-inhouse/eslint-plugin": "^1.6.0",
         "@typescript-eslint/eslint-plugin": "6.10.0",
         "@typescript-eslint/parser": "6.10.0",
         "eslint": "8.53.0",


### PR DESCRIPTION
**Overview:**
- npm failed to resolve package with version number 1.6.0, published open source version is 1.6.1

<img width="761" alt="image" src="https://github.com/diia-open-source/be-eslint-config/assets/6419758/2d8f25e8-6a24-421f-9869-73838014ef87">

**Solution:**
- allow npm resolver to use upper version during resolving

**Details:**
- npm uses the tilde (~) and caret (^) to designate which patch and minor versions to use respectively.
- So if you see ~1.0.2 it means to install version 1.0.2 or the latest patch version such as 1.0.4
- If you see ^1.0.2 it means to install version 1.0.2 or the latest minor or patch version such as 1.1.0.

